### PR TITLE
Update Submodules to latest version and also README for local running instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,12 @@ You will need to install Rust, Node, Redis.
 
 ```bash
 git clone --recurse-submodules https://github.com/0xMerso/tycho-orderbook-web web
+cd web
 git submodule update --remote --recursive # Update the submodules to the latest version.
+```
 
+```bash
+# Run the backend server
 cp -n back/.env.ex back/.env # Duplicate .env.ex to .env, if not already existing (.env is gitignored)
 cd back
 # Launch 'ethereum' Axum API + Redis. You can use 'base' instead
@@ -27,6 +31,7 @@ sh ops/local.api.test.sh ethereum
 ```
 
 ```bash
+# Run the frontend
 cd front/front
 pnpm install
 pnpm dev

--- a/README.md
+++ b/README.md
@@ -1,13 +1,33 @@
-
 # tycho-orderbook-web
 
 This repository contains the architecture to run [orderbook.wtf](https://orderbook.wtf) infra, with the Rust SDK **tycho-orderbook** and a NextJS front (as submodules).
 
-Together, they're used to visualize the onchain liquidity of AMMs in a familiar orderbook format, thanks to [Tycho](https://docs.propellerheads.xyz/tycho).  
+Together, they're used to visualize the onchain liquidity of AMMs in a familiar orderbook format, thanks to [Tycho](https://docs.propellerheads.xyz/tycho).
 
 You can run the architecture with the given script, after cloning this repo.
 
     git clone --recurse-submodules https://github.com/0xMerso/tycho-orderbook-web web
     sh launch.sh
 
-Get started quickly with the [documentation](https://tycho-orderbook.gitbook.io/docs).  
+Get started quickly with the [documentation](https://tycho-orderbook.gitbook.io/docs) or as below.
+
+If you prefer to build and run the application directly, we provide shell scripts for simple startup.
+You will need to install Rust, Node, Redis.
+
+```bash
+git clone --recurse-submodules https://github.com/0xMerso/tycho-orderbook-web web
+git submodule update --remote --recursive # Update the submodules to the latest version.
+
+cp -n back/.env.ex back/.env # Duplicate .env.ex to .env, if not already existing (.env is gitignored)
+cd back
+# Launch 'ethereum' Axum API + Redis. You can use 'base' instead
+sh ops/local.api.start.sh ethereum
+# Tests
+sh ops/local.api.test.sh ethereum
+```
+
+```bash
+cd front/front
+pnpm install
+pnpm dev
+```


### PR DESCRIPTION
The repo didn't have the latest commit from the submodule https://github.com/fberger-xyz/orderbook-wtf

Also, the instructions on https://tycho-orderbook.gitbook.io/docs/application/run-locally were missing a couple of commands.
```bash
git submodule update --remote --recursive # Update the submodules to the latest version.
cp -n back/.env.ex back/.env # Duplicate .env.ex to .env, if not already existing (.env is gitignored)
```

Updated the README to include these instructions now.

TODO
- [ ]  Should also update https://tycho-orderbook.gitbook.io as well.

